### PR TITLE
Support YouTube transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ python generate_cards.py https://example.com --key sk-...
 python generate_cards.py https://example.com --no-translate --key sk-...
 ```
 
-- 生成カードは `Library/` 以下に自動で振り分け  
+- 生成カードは `Library/` 以下に自動で振り分け
 - ダイジェストは `Library/_digests/` 以下に日付別保存
   - 最新版は `Library/_daily_digest.md` としてリンク/コピー
+- YouTube URL を指定した場合は音声を取得し、Whisper で文字起こし後にカード化
 
 ## フォルダ構成例
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ openai>=1.25
 python-dateutil>=2.9
 pytest>=8.2
 tqdm==4.66.4
+yt-dlp>=2024.4
+openai-whisper>=20231111

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,0 +1,39 @@
+import sys, types, pathlib, datetime
+
+# Stub modules not required for unit tests
+for name in ['yt_dlp', 'whisper', 'httpx', 'trafilatura', 'yaml', 'slugify', 'dateparser', 'openai', 'tqdm']:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+
+sys.modules['slugify'].slugify = lambda text, **k: text
+
+import generate_cards
+
+
+def test_process_youtube_moves_audio(monkeypatch, tmp_path):
+    lib_dir = tmp_path / 'Library'
+    digest_dir = lib_dir / '_digests'
+    lib_dir.mkdir()
+    digest_dir.mkdir()
+
+    monkeypatch.setattr(generate_cards, 'LIBRARY_DIR', lib_dir)
+    monkeypatch.setattr(generate_cards, 'DIGEST_DIR', digest_dir)
+
+    audio = tmp_path / 'a.mp3'
+    audio.write_bytes(b'data')
+    meta = {
+        'title': 'Video',
+        'publication_date': '2024-01-01',
+        'author_family': '',
+        'author_given': '',
+        'keywords': [],
+        'text': 'hello world'
+    }
+    monkeypatch.setattr(generate_cards, 'is_youtube_url', lambda url: True)
+    monkeypatch.setattr(generate_cards, 'process_youtube_url', lambda url: (meta, audio))
+    monkeypatch.setattr(generate_cards, 'build_card', lambda m, u, ad, skip_translation=False: 'body')
+    monkeypatch.setattr(generate_cards, 'save_card', lambda c, m: lib_dir / 'card.md')
+
+    generate_cards._process_urls(['https://youtu.be/xyz'])
+
+    assert (lib_dir / 'card.mp3').exists()


### PR DESCRIPTION
## Summary
- download audio from YouTube URLs and transcribe locally with Whisper
- move the audio file next to the generated card
- mention YouTube handling in README
- add yt-dlp and openai-whisper requirements
- test new YouTube path

## Testing
- `bash scripts/setup.sh`
- `/root/.pyenv/versions/3.11.12/bin/pytest -q`