### PR TITLE
Remove YouTube temp dirs

### DIFF
--- a/generate_cards.py
+++ b/generate_cards.py
@@ -568,6 +568,7 @@ def _process_urls(urls: list[str], skip_translation: bool = False):
             if audio_temp:
                 dest = fp.with_suffix(audio_temp.suffix)
                 shutil.move(str(audio_temp), dest)
+                shutil.rmtree(audio_temp.parent, ignore_errors=True)
             rel = fp.relative_to(LIBRARY_DIR)
             new_entries.append((
                 meta["title"],

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -19,7 +19,9 @@ def test_process_youtube_moves_audio(monkeypatch, tmp_path):
     monkeypatch.setattr(generate_cards, 'LIBRARY_DIR', lib_dir)
     monkeypatch.setattr(generate_cards, 'DIGEST_DIR', digest_dir)
 
-    audio = tmp_path / 'a.mp3'
+    tmp_audio_dir = tmp_path / 'yt'
+    tmp_audio_dir.mkdir()
+    audio = tmp_audio_dir / 'a.mp3'
     audio.write_bytes(b'data')
     meta = {
         'title': 'Video',
@@ -37,3 +39,34 @@ def test_process_youtube_moves_audio(monkeypatch, tmp_path):
     generate_cards._process_urls(['https://youtu.be/xyz'])
 
     assert (lib_dir / 'card.mp3').exists()
+
+
+def test_process_youtube_temp_dir_removed(monkeypatch, tmp_path):
+    lib_dir = tmp_path / 'Library'
+    digest_dir = lib_dir / '_digests'
+    lib_dir.mkdir()
+    digest_dir.mkdir()
+
+    monkeypatch.setattr(generate_cards, 'LIBRARY_DIR', lib_dir)
+    monkeypatch.setattr(generate_cards, 'DIGEST_DIR', digest_dir)
+
+    tmp_audio_dir = tmp_path / 'yt_tmp'
+    tmp_audio_dir.mkdir()
+    audio = tmp_audio_dir / 'b.mp3'
+    audio.write_bytes(b'data')
+    meta = {
+        'title': 'Video',
+        'publication_date': '2024-01-01',
+        'author_family': '',
+        'author_given': '',
+        'keywords': [],
+        'text': 'hello world',
+    }
+    monkeypatch.setattr(generate_cards, 'is_youtube_url', lambda url: True)
+    monkeypatch.setattr(generate_cards, 'process_youtube_url', lambda url: (meta, audio))
+    monkeypatch.setattr(generate_cards, 'build_card', lambda m, u, ad, skip_translation=False: 'body')
+    monkeypatch.setattr(generate_cards, 'save_card', lambda c, m: lib_dir / 'card.md')
+
+    generate_cards._process_urls(['https://youtu.be/xyz'])
+
+    assert not tmp_audio_dir.exists()


### PR DESCRIPTION
## Summary
- delete temporary YouTube download directory after moving the audio
- update YouTube test to use a dedicated directory
- add regression test verifying temp dir removal

## Testing
- `bash scripts/setup.sh`
- `python -m pytest -q`