### PR TITLE
Fix CI Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,6 @@ jobs:
 
       - uses: actions/setup-python@v5        # ← 追加
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - run: python -m pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
       - run: python -m pytest -q


### PR DESCRIPTION
## Notes
- couldn't run `scripts/setup.sh` due to missing network but installed pytest manually for tests

## Summary
- use Python 3.11 in CI to match README and setup script

## Testing
- `pytest -q`